### PR TITLE
Bake operators fix

### DIFF
--- a/bake_operators.py
+++ b/bake_operators.py
@@ -19,6 +19,7 @@
 # <pep8 compliant>
 
 import bpy
+import bpy_extras.anim_utils
 import mathutils
 import math
 import itertools
@@ -208,14 +209,15 @@ class BakingOperator(object):
             source_bones_matrix_basis.append(context.object.pose.bones[source_bone.name].matrix_basis.copy())
             source_bone.select = True
 
-        # Blender 2.81 : Another hack for another bug in the bake operator
-        # removing from the selection objects which are not the current one
-        for obj in context.selected_objects:
-            if obj is not context.object:
-                obj.select_set(state=False)
-
-        bpy.ops.nla.bake(frame_start=self.frame_start, frame_end=self.frame_end, only_selected=True, bake_types={'POSE'}, visual_keying=True)
-        baked_action = context.object.animation_data.action
+        baked_action = bpy_extras.anim_utils.bake_action(
+            context.object,
+            action=None,
+            frames=range(self.frame_start, self.frame_end + 1),
+            only_selected=True,
+            do_pose=True,
+            do_object=False,
+            do_visual_keying=True,
+        )
 
         # restoring context
         for source_bone, matrix_basis in zip(source_bones, source_bones_matrix_basis):
@@ -262,6 +264,10 @@ class ANIM_OT_carWheelsRotationBake(bpy.types.Operator, BakingOperator):
         bones = set(wheel_bones + brake_bones)
         baked_action = self._bake_action(context, *bones)
 
+        if baked_action is None:
+            self.report({'WARNING'}, "Existing action failed to bake. Won't bake wheel rotation")
+            return
+
         try:
             for wheel_bone, brake_bone in zip(wheel_bones, brake_bones):
                 self._bake_wheel_rotation(context, baked_action, wheel_bone, brake_bone)
@@ -301,6 +307,10 @@ class ANIM_OT_carWheelsRotationBake(bpy.types.Operator, BakingOperator):
 
     def _bake_wheel_rotation(self, context, baked_action, bone, brake_bone):
         fc_rot = create_property_animation(context, bone.name.replace('MCH-', ''))
+
+        # Reset the transform of the wheel bone, otherwise baking yields wrong results
+        pb: bpy.types.PoseBone = context.object.pose.bones[bone.name]
+        pb.matrix_basis.identity()
 
         for f, distance in self._evaluate_distance_per_frame(baked_action, bone, brake_bone):
             kf = fc_rot.keyframe_points.insert(f, distance)
@@ -377,15 +387,24 @@ class ANIM_OT_carSteeringBake(bpy.types.Operator, BakingOperator):
         clear_property_animation(context, 'Steering.rotation')
         fix_old_steering_rotation(context.object)
         fc_rot = create_property_animation(context, 'Steering.rotation')
-        action = self._bake_action(context, bone)
+
+        baked_action = self._bake_action(context, bone)
+        if baked_action is None:
+            self.report({'WARNING'}, "Existing action failed to bake. Won't bake steering rotation")
+            return
 
         try:
-            for f, steering_pos in self._evaluate_rotation_per_frame(action, bone_offset, bone):
+            # Reset the transform of the steering bone, because baking action manipulates the transform
+            # and evaluate_rotation_frame expects it at it's default position
+            pb: bpy.types.PoseBone = context.object.pose.bones[bone.name]
+            pb.matrix_basis.identity()
+
+            for f, steering_pos in self._evaluate_rotation_per_frame(baked_action, bone_offset, bone):
                 kf = fc_rot.keyframe_points.insert(f, steering_pos)
                 kf.type = 'JITTER'
                 kf.interpolation = 'LINEAR'
         finally:
-            bpy.data.actions.remove(action)
+            bpy.data.actions.remove(baked_action)
 
 
 class ANIM_OT_carClearSteeringWheelsRotation(bpy.types.Operator):


### PR DESCRIPTION
By using `bpy_extras.anim_utils` module directly there is more control over baking actions, but the steering pose transform bone needs to be reset in order to bake steering correctly.

The root of the issues was in inconsistency between the `bpy.ops.nla.bake` operator, if the internal functions are used directly it's behaviour is more controlled.

Blend with follow path constraint and baked rotation and steering from this PR. (Blender 3.4)
[bmw27_with_rig.zip](https://github.com/digicreatures/rigacar/files/10725967/bmw27_with_rig.zip)

Closes #93, Closes #95, Closes #97, Closes #98

**Edit: .zip with changes from this MR:**
[rigacar-bake-operator-fix.zip](https://github.com/digicreatures/rigacar/files/11303864/rigacar-bake-operator-fix.zip)
