### PR TITLE
Add Blender 5.1 compatibility fixes to car rig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Local agent workspace
+.codenomad/

--- a/car_rig.py
+++ b/car_rig.py
@@ -26,10 +26,11 @@ import re
 from math import inf
 from rna_prop_ui import rna_idprop_ui_create
 
-CUSTOM_SHAPE_LAYER = 13
-MCH_BONE_EXTENSION_LAYER = 14
-DEF_BONE_LAYER = 15
-MCH_BONE_LAYER = 31
+DEFAULT_VISIBLE_LAYER = 'CarRig_Default_Ctrls' # New Setting for Blender4.0
+CUSTOM_SHAPE_LAYER    = 'CarRig_Custom_Ctrls'#13
+MCH_BONE_EXTENSION_LAYER = 'CarRig_MCH_Bone_Ext'#14
+DEF_BONE_LAYER = 'CarRig_Def_Bone' #15
+MCH_BONE_LAYER = 'CarRig_MCH_Bone' #31
 
 
 def deselect_edit_bones(ob):
@@ -53,7 +54,7 @@ def create_constraint_influence_driver(ob, cns, driver_data_path, base_influence
     targ.data_path = driver_data_path
 
     if base_influence != 1.0:
-        fmod = fcurve.modifiers[0]
+        fmod = fcurve.modifiers[0] if fcurve.modifiers else fcurve.modifiers.new('GENERATOR')
         fmod.mode = 'POLYNOMIAL'
         fmod.poly_order = 1
         fmod.coefficients = (0, base_influence)
@@ -88,13 +89,11 @@ def create_translation_x_driver(ob, bone, driver_data_path):
 
 
 def create_bone_group(pose, group_name, color_set, bone_names):
-    group = pose.bone_groups.new(name=group_name)
-    group.color_set = color_set
+    
     for bone_name in bone_names:
         bone = pose.bones.get(bone_name)
         if bone is not None:
-            bone.bone_group = group
-
+            bone.color.palette = color_set
 
 def name_range(prefix, nb=1000):
     if nb > 0:
@@ -112,39 +111,110 @@ def get_widget(name):
     return widget
 
 
+def extend_bounds_xyz_with_box(xyz, bound_box, matrix_world):
+    for p in bound_box:
+        world_p = matrix_world @ mathutils.Vector(p)
+        xyz[0] = min(world_p.x, xyz[0])
+        xyz[1] = max(world_p.x, xyz[1])
+        xyz[2] = min(world_p.y, xyz[2])
+        xyz[3] = max(world_p.y, xyz[3])
+        xyz[4] = min(world_p.z, xyz[4])
+        xyz[5] = max(world_p.z, xyz[5])
+
+
+def extend_bounds_xyz_from_collection_instance(xyz, obj):
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    found = False
+    for inst in depsgraph.object_instances:
+        if not inst.is_instance:
+            continue
+
+        parent = getattr(inst, 'parent', None)
+        parent_original = getattr(parent, 'original', None)
+        if parent_original != obj:
+            continue
+
+        inst_object = getattr(inst, 'object', None)
+        if inst_object is None or inst_object.type == 'EMPTY' or not inst_object.bound_box:
+            continue
+
+        extend_bounds_xyz_with_box(xyz, inst_object.bound_box, inst.matrix_world.copy())
+        found = True
+
+    return found
+
+
+def extend_bounds_xyz(xyz, obj, parent_matrix=None, recurse_children=True):
+    if parent_matrix is None:
+        parent_matrix = mathutils.Matrix.Identity(4)
+
+    omatrix = parent_matrix @ obj.matrix_world
+    if obj.instance_type == 'COLLECTION' and obj.instance_collection is not None:
+        if extend_bounds_xyz_from_collection_instance(xyz, obj):
+            return
+        for inst_obj in obj.instance_collection.all_objects:
+            extend_bounds_xyz(xyz, inst_obj, omatrix, recurse_children=False)
+        return
+
+    if obj.type != 'EMPTY' and obj.bound_box:
+        extend_bounds_xyz_with_box(xyz, obj.bound_box, omatrix)
+
+    if recurse_children:
+        for child in obj.children:
+            extend_bounds_xyz(xyz, child, omatrix)
+
+
+def object_bounds_xyz(*objs):
+    xyz = [inf, -inf, inf, -inf, inf, -inf]
+    for obj in objs:
+        extend_bounds_xyz(xyz, obj)
+    return xyz if xyz[0] != inf else None
+
+
 def define_custom_property(target, name, value, description=None, overridable=True):
     rna_idprop_ui_create(target, name, default=value, description=description, overridable=overridable, min=-inf, max=inf)
 
 
 def dispatch_bones_to_armature_layers(ob):
+    '''Bone Collections were introduced in Blender 4.0 as replacement of Armature Layers and Bone Groups.'''
+    amt = bpy.context.object.data
+    default_visible_layer       = amt.collections.new(name= DEFAULT_VISIBLE_LAYER) 
+    custom_shape_layer          = amt.collections.new(name= CUSTOM_SHAPE_LAYER) #13
+    def_bone_layer              = amt.collections.new(name= DEF_BONE_LAYER) #15
+    mch_bone_layer              = amt.collections.new(name= MCH_BONE_LAYER) #31
+    mch_bone_extension_layer    = amt.collections.new(name= MCH_BONE_EXTENSION_LAYER) #14
+    
+    #set visiblity
+    custom_shape_layer.is_visible       = False
+    def_bone_layer.is_visible           = False
+    mch_bone_extension_layer.is_visible = False
+    mch_bone_layer.is_visible           = False
+
     re_mch_bone = re.compile(r'^MCH-Wheel(Brake)?\.(Ft|Bk)\.[LR](\.\d+)?$')
-    default_visible_layers = [False] * 32
-
     for b in ob.data.bones:
-        layers = [False] * 32
         if b.name.startswith('DEF-'):
-            layers[DEF_BONE_LAYER] = True
+            def_bone_layer.assign(b)
         elif b.name.startswith('MCH-'):
-            layers[MCH_BONE_LAYER] = True
+            mch_bone_layer.assign(b)
             if b.name in ('MCH-Body', 'MCH-Steering') or re_mch_bone.match(b.name):
-                layers[MCH_BONE_EXTENSION_LAYER] = True
+                mch_bone_extension_layer.assign(b)
         else:
-            layer_num = ob.pose.bones[b.name].bone_group_index
-            layers[layer_num] = True
-            default_visible_layers[layer_num] = True
-        b.layers = layers
+            default_visible_layer.assign(b)
+            pass
 
-    ob.data.layers = default_visible_layers
-
-    shape_bone_layers = [False] * 32
-    shape_bone_layers[CUSTOM_SHAPE_LAYER] = True
     for b in ob.pose.bones:
         if b.custom_shape:
             if b.custom_shape_transform:
                 ob.pose.bones[b.custom_shape_transform.name].custom_shape = b.custom_shape
-                ob.data.bones[b.custom_shape_transform.name].layers = shape_bone_layers
+                custom_shape_layer.assign(ob.pose.bones[b.custom_shape_transform.name])
+                #ob.data.bones[b.custom_shape_transform.name].layers = shape_bone_layers
             else:
-                ob.data.bones[b.name].layers[CUSTOM_SHAPE_LAYER] = True
+                default_visible_layer.assign(ob.data.bones[b.name])
+                #ob.data.bones[b.name].layers[CUSTOM_SHAPE_LAYER] = True
+    
+    #remove custome shape from default layer
+    for bone in custom_shape_layer.bones:
+        default_visible_layer.unassign(bone)
 
 
 class NameSuffix(object):
@@ -186,24 +256,9 @@ class BoundingBox(object):
         if not objs:
             self.__xyz = [bone.head.x - bone.length / 2, bone.head.x + bone.length / 2, bone.head.y - bone.length, bone.head.y + bone.length, .0, bone.head.z * 2]
         else:
-            self.__xyz = [inf, -inf, inf, -inf, inf, -inf]
-            self.__compute(mathutils.Matrix(), *objs)
-
-    def __compute(self, pmatrix, *objs):
-        for obj in objs:
-            omatrix = pmatrix @ obj.matrix_world
-            if obj.instance_type == 'COLLECTION':
-                self.__compute(omatrix, *obj.instance_collection.all_objects)
-            elif obj.bound_box:
-                for p in obj.bound_box:
-                    world_p = omatrix @ mathutils.Vector(p)
-                    self.__xyz[0] = min(world_p.x, self.__xyz[0])
-                    self.__xyz[1] = max(world_p.x, self.__xyz[1])
-                    self.__xyz[2] = min(world_p.y, self.__xyz[2])
-                    self.__xyz[3] = max(world_p.y, self.__xyz[3])
-                    self.__xyz[4] = min(world_p.z, self.__xyz[4])
-                    self.__xyz[5] = max(world_p.z, self.__xyz[5])
-            self.__compute(pmatrix, *obj.children)
+            self.__xyz = object_bounds_xyz(*objs)
+            if self.__xyz is None:
+                self.__xyz = [bone.head.x - bone.length / 2, bone.head.x + bone.length / 2, bone.head.y - bone.length, bone.head.y + bone.length, .0, bone.head.z * 2]
 
     @property
     def center(self):
@@ -435,8 +490,12 @@ def generate_constraint_on_wheel_brake_bone(wheel_brake_pose_bone, wheel_pose_bo
     wheel_brake_pose_bone.lock_scale = (True, False, False)
     wheel_brake_pose_bone.custom_shape = get_widget('WGT-CarRig.WheelBrake')
     wheel_brake_pose_bone.bone.show_wire = True
-    wheel_brake_pose_bone.bone_group = wheel_pose_bone.bone_group
-    wheel_brake_pose_bone.bone.layers = wheel_pose_bone.bone.layers
+    amt = bpy.context.object.data
+    groups = amt.collections
+    for group in groups:
+        for bone in group.bones:
+            if bone.name == wheel_pose_bone.name:
+                group.assign(wheel_brake_pose_bone.bone)
 
     cns = wheel_brake_pose_bone.constraints.new('LIMIT_SCALE')
     cns.name = 'Brakes'
@@ -454,6 +513,20 @@ def generate_constraint_on_wheel_brake_bone(wheel_brake_pose_bone, wheel_pose_bo
     cns.use_min_z = True
     cns.min_z = .5
     cns.max_z = 1.0
+
+
+def default_bones_position():
+    return {
+        'Body':       mathutils.Vector((0.0,  0,  .8)),
+        'Wheel.Ft.L': mathutils.Vector((0.9, -2,  .5)),
+        'Wheel.Ft.R': mathutils.Vector((-.9, -2,  .5)),
+        'Wheel.Bk.L': mathutils.Vector((0.9,  2,  .5)),
+        'Wheel.Bk.R': mathutils.Vector((-.9,  2,  .5)),
+        'WheelBrake.Ft.L': mathutils.Vector((0.8, -2,  .5)),
+        'WheelBrake.Ft.R': mathutils.Vector((-.8, -2,  .5)),
+        'WheelBrake.Bk.L': mathutils.Vector((0.8,  2,  .5)),
+        'WheelBrake.Bk.R': mathutils.Vector((-.8,  2,  .5))
+    }
 
 
 class ArmatureGenerator(object):
@@ -1251,17 +1324,7 @@ class OBJECT_OT_armatureCarDeformationRig(bpy.types.Operator):
         layout.prop(self, 'back_wheel_brakes_pos_delta')
 
     def invoke(self, context, event):
-        self.bones_position = {
-            'Body':       mathutils.Vector((0.0,  0,  .8)),
-            'Wheel.Ft.L': mathutils.Vector((0.9, -2,  .5)),
-            'Wheel.Ft.R': mathutils.Vector((-.9, -2,  .5)),
-            'Wheel.Bk.L': mathutils.Vector((0.9,  2,  .5)),
-            'Wheel.Bk.R': mathutils.Vector((-.9,  2,  .5)),
-            'WheelBrake.Ft.L': mathutils.Vector((0.8, -2,  .5)),
-            'WheelBrake.Ft.R': mathutils.Vector((-.8, -2,  .5)),
-            'WheelBrake.Bk.L': mathutils.Vector((0.8,  2,  .5)),
-            'WheelBrake.Bk.R': mathutils.Vector((-.8,  2,  .5))
-        }
+        self.bones_position = default_bones_position()
         self.target_objects_name = {}
 
         has_body_target = self._find_target_object(context, 'Body')
@@ -1306,6 +1369,11 @@ class OBJECT_OT_armatureCarDeformationRig(bpy.types.Operator):
 
     def execute(self, context):
         """Creates the meta rig with basic bones"""
+        if not hasattr(self, 'bones_position'):
+            self.bones_position = default_bones_position()
+        if not hasattr(self, 'target_objects_name'):
+            self.target_objects_name = {}
+
         amt = bpy.data.armatures.new('Car Rig Data')
         amt['Car Rig'] = False
 
@@ -1315,7 +1383,7 @@ class OBJECT_OT_armatureCarDeformationRig(bpy.types.Operator):
         # Could be a better fix (steal code from other addons).
         try:
             bpy.ops.object.mode_set(mode='EDIT')
-        except TypeError:
+        except (TypeError, RuntimeError):
             self.report({'ERROR'}, "Cannot edit the new armature! Please make sure the active collection is visible and editable")
             return {'CANCELLED'}
 
@@ -1356,7 +1424,9 @@ class OBJECT_OT_armatureCarDeformationRig(bpy.types.Operator):
             target_obj = bpy.context.scene.objects[target_obj_name]
             if name == 'Body':
                 b.tail = b.head
-                b.tail.y += target_obj.dimensions[1] / 2 if target_obj.dimensions and target_obj.dimensions[0] != 0 else 1
+                body_bounds = object_bounds_xyz(target_obj)
+                body_length = body_bounds[3] - body_bounds[2] if body_bounds is not None else target_obj.dimensions[1]
+                b.tail.y += body_length / 2 if body_length != 0 else 1
             target_obj.parent = rig
             target_obj.parent_bone = b.name
             target_obj.parent_type = 'BONE'


### PR DESCRIPTION
## Summary
- replace legacy armature layers and bone groups with bone collections and palette assignments so the car rig works on Blender 5.1
- improve object bounds handling for collection instances and reuse it when sizing the body rig from target geometry
- harden rig generation by initializing operator state in execute, creating missing driver modifiers, and handling mode-switch runtime failures